### PR TITLE
feat:  add cloneVNodes util

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,9 +1,17 @@
 const { mergeConfig } = require('vite')
+const path = require('path')
+const dirPath = path.resolve(__dirname, '../src')
 
 module.exports = {
   async viteFinal(config, { configType }) {
     config.resolve.dedupe = ['@storybook/client-api']
-    return config
+    return mergeConfig(config, {
+      resolve: {
+        alias: {
+          '@': dirPath
+        }
+      }
+    })
   },
   stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
   addons: ['@storybook/addon-links', '@storybook/addon-essentials'],

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,6 @@
 {
-  "recommendations": ["johnsoncodehk.volar", "johnsoncodehk.vscode-typescript-vue-plugin"]
+  "recommendations": [
+    "Vue.volar",
+    "Vue.vscode-typescript-vue-plugin"
+  ]
 }

--- a/src/utils/vue-helper.ts
+++ b/src/utils/vue-helper.ts
@@ -8,13 +8,17 @@ import { cloneVNode, Fragment } from 'vue'
  * @param {VNode[]} nodes - Array of VNodes
  * @param {boolean} [flattenFragments=false] - Whether to flatten fragments or not. `false` by default.
  */
-const cloneVNodes = (nodes: VNode[], customProps = {}, flattenFragments = false): VNode[] => {
+const cloneVNodes = (
+  nodes: VNode[],
+  customProps = {} as Record<string, unknown>,
+  flattenFragments = false
+): VNode[] => {
   return nodes.reduce((flatArray, child) => {
     if (flattenFragments && child.type === Fragment) {
-      return cloneVNodes(child.children as VNode[], customProps)
+      return cloneVNodes(child.children as VNode[], { ...customProps, ...child.props })
     }
 
-    return flatArray.concat(cloneVNode(child, customProps))
+    return flatArray.concat(cloneVNode(child, { ...customProps, ...child.props }))
   }, [] as VNode[])
 }
 

--- a/src/utils/vue-helper.ts
+++ b/src/utils/vue-helper.ts
@@ -1,0 +1,21 @@
+import type { VNode } from 'vue'
+import { cloneVNode, Fragment } from 'vue'
+
+/**
+ * Generates an array of cloned VNodes, [since they are immutable]{@link https://github.com/vuejs/core/issues/1082#issuecomment-622519277}.
+ * Optionally, can flatten VNodes of type {@link Fragment}.
+ *
+ * @param {VNode[]} nodes - Array of VNodes
+ * @param {boolean} [flattenFragments=false] - Whether to flatten fragments or not. `false` by default.
+ */
+const cloneVNodes = (nodes: VNode[], customProps = {}, flattenFragments = false): VNode[] => {
+  return nodes.reduce((flatArray, child) => {
+    if (flattenFragments && child.type === Fragment) {
+      return cloneVNodes(child.children as VNode[], customProps)
+    }
+
+    return flatArray.concat(cloneVNode(child, customProps))
+  }, [] as VNode[])
+}
+
+export { cloneVNodes }


### PR DESCRIPTION
## Description

This PR adds a utility to clone `VNode`s passed to a slot in the component. Fixes path resolver in stories and updates the extension recommendations to Volar's new namespace.

### Related tickets, documents

Fixes PLT-4675

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Changes in this PR

- Add function to clone VNodes passed to a slot.
- Fix path resolver in stories.
- Fix vscode extension recommendations.


