### PR TITLE
fix: `cloneVNodes` concat logic

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -3,3 +3,7 @@ version = 1
 [[analyzers]]
 name = "secrets"
 enabled = true
+
+[[analyzers]]
+name = "test-coverage"
+enabled = true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,11 +13,13 @@ jobs:
           node-version: '14'
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile --ignore-scripts
-      - run: pnpm run --if-present build
+      - run: pnpm run build
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: pnpm/action-setup@v2
         with:
           version: 7.x.x
@@ -26,4 +28,10 @@ jobs:
           node-version: '14'
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile --ignore-scripts
-      - run: pnpm run --if-present test:unit --passWithNoTests
+      - run: pnpm run test:unit
+      - name: Report results to DeepSource
+        run: |
+          curl https://deepsource.io/cli | sh
+          ./bin/deepsource report --analyzer test-coverage --key javascript --value-file .coverage/cobertura-coverage.xml
+        env:
+          DEEPSOURCE_DSN: ${{ secrets.DEEPSOURCE_DSN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,6 @@ jobs:
       - name: Report results to DeepSource
         run: |
           curl https://deepsource.io/cli | sh
-          ./bin/deepsource report --analyzer test-coverage --key javascript --value-file .coverage/cobertura-coverage.xml
+          ./bin/deepsource report --analyzer test-coverage --key javascript --value-file coverage/cobertura-coverage.xml
         env:
           DEEPSOURCE_DSN: ${{ secrets.DEEPSOURCE_DSN }}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,9 @@
 {
   "recommendations": [
     "Vue.volar",
-    "Vue.vscode-typescript-vue-plugin"
+    "zixuanchen.vitest-explorer",
+    "cpylua.language-postcss",
+    "csstools.postcss",
+    "bradlc.vscode-tailwindcss"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@vue/compiler-sfc": "^3.2.33",
     "@vue/eslint-config-prettier": "^7.0.0",
     "@vue/eslint-config-typescript": "^10.0.0",
-    "@vue/test-utils": "^2.0.0-rc.18",
+    "@vue/test-utils": "^2.0.0",
     "@vue/tsconfig": "^0.1.3",
     "autoprefixer": "^10.4.4",
     "babel-loader": "^8.2.4",
@@ -57,7 +57,7 @@
     "typescript": "~4.6.3",
     "unplugin-icons": "^0.14.3",
     "vite": "^2.9.1",
-    "vitest": "^0.8.1",
+    "vitest": "^0.8.5",
     "vue-loader": "^16.8.3",
     "vue-tsc": "^0.33.9"
   }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build": "vue-tsc --declaration --emitDeclarationOnly --project tsconfig.build.json && vite build",
     "build:storybook": "build-storybook",
     "preview": "vite preview --port 5050",
-    "test:unit": "vitest --environment jsdom",
+    "test:unit": "vitest --environment jsdom --coverage",
     "typecheck": "vue-tsc --noEmit -p tsconfig.vitest.json --composite false",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ specifiers:
   '@vue/compiler-sfc': ^3.2.33
   '@vue/eslint-config-prettier': ^7.0.0
   '@vue/eslint-config-typescript': ^10.0.0
-  '@vue/test-utils': ^2.0.0-rc.18
+  '@vue/test-utils': ^2.0.0
   '@vue/tsconfig': ^0.1.3
   autoprefixer: ^10.4.4
   babel-loader: ^8.2.4
@@ -29,7 +29,7 @@ specifiers:
   typescript: ~4.6.3
   unplugin-icons: ^0.14.3
   vite: ^2.9.1
-  vitest: ^0.8.1
+  vitest: ^0.8.5
   vue: ^3.2.33
   vue-loader: ^16.8.3
   vue-tsc: ^0.33.9
@@ -53,7 +53,7 @@ devDependencies:
   '@vue/compiler-sfc': 3.2.33
   '@vue/eslint-config-prettier': 7.0.0_xv6nuostqdukqfvwtczhahsjgy
   '@vue/eslint-config-typescript': 10.0.0_vgrwpc24fjl34jxz24rwy6le7a
-  '@vue/test-utils': 2.0.0-rc.20_vue@3.2.33
+  '@vue/test-utils': 2.0.0_vue@3.2.33
   '@vue/tsconfig': 0.1.3_@types+node@16.11.27
   autoprefixer: 10.4.4_postcss@8.4.12
   babel-loader: 8.2.5_@babel+core@7.17.9
@@ -203,7 +203,16 @@ packages:
     resolution: {integrity: sha512-81YO9gGx6voPXlvYdZBliFXAZU8vZ9AZ6z+CjlmcnaeOcYSFbMTpdeDUO9xD9dh/68Vq03I8ZspfUTPfitcDHg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.18.0
+      '@babel/types': 7.18.2
+      '@jridgewell/gen-mapping': 0.3.1
+      jsesc: 2.5.2
+    dev: true
+
+  /@babel/generator/7.18.2:
+    resolution: {integrity: sha512-W1lG5vUwFvfMd8HVXqdfbuG7RuaSrTCCD8cl8fP8wOivdbtbIg2Db3IWUcgvfxKbbn6ZBGYRW/Zk1MIwK49mgw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.18.2
       '@jridgewell/gen-mapping': 0.3.1
       jsesc: 2.5.2
     dev: true
@@ -212,7 +221,7 @@ packages:
     resolution: {integrity: sha512-s6t2w/IPQVTAET1HitoowRGXooX8mCgtuP5195wD/QJPV6wYjpujCGF7JuMODVX2ZAJOf1GT6DT9MHEZvLOFSw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.17.0
+      '@babel/types': 7.18.2
     dev: true
 
   /@babel/helper-builder-binary-assignment-operator-visitor/7.16.7:
@@ -220,7 +229,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-explode-assignable-expression': 7.16.7
-      '@babel/types': 7.17.0
+      '@babel/types': 7.18.2
     dev: true
 
   /@babel/helper-compilation-targets/7.17.10_@babel+core@7.17.9:
@@ -456,7 +465,7 @@ packages:
     resolution: {integrity: sha512-KyUenhWMC8VrxzkGP0Jizjo4/Zx+1nNZhgocs+gLzyZyB8SHidhoq9KK/8Ato4anhwsivfkBLftky7gvzbZMtQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.17.0
+      '@babel/types': 7.18.2
     dev: true
 
   /@babel/helper-function-name/7.17.9:
@@ -478,7 +487,7 @@ packages:
     resolution: {integrity: sha512-thxXgnQ8qQ11W2wVUObIqDL4p148VMxkt5T/qpN5k2fboRyzFGFmKsTGViquyM5QHKUy48OZoca8kw4ajaDPyw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.17.0
+      '@babel/types': 7.18.2
     dev: true
 
   /@babel/helper-module-imports/7.16.7:
@@ -515,7 +524,7 @@ packages:
       '@babel/helper-validator-identifier': 7.16.7
       '@babel/template': 7.16.7
       '@babel/traverse': 7.18.0
-      '@babel/types': 7.18.0
+      '@babel/types': 7.18.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -524,7 +533,7 @@ packages:
     resolution: {integrity: sha512-EtgBhg7rd/JcnpZFXpBy0ze1YRfdm7BnBX4uKMBd3ixa3RGAE002JZB66FJyNH7g0F38U05pXmA5P8cBh7z+1w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.17.0
+      '@babel/types': 7.18.2
     dev: true
 
   /@babel/helper-plugin-utils/7.10.4:
@@ -547,7 +556,7 @@ packages:
     dependencies:
       '@babel/helper-annotate-as-pure': 7.16.7
       '@babel/helper-wrap-function': 7.16.8
-      '@babel/types': 7.17.0
+      '@babel/types': 7.18.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -560,7 +569,7 @@ packages:
       '@babel/helper-member-expression-to-functions': 7.17.7
       '@babel/helper-optimise-call-expression': 7.16.7
       '@babel/traverse': 7.17.9
-      '@babel/types': 7.17.0
+      '@babel/types': 7.18.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -576,7 +585,7 @@ packages:
     resolution: {integrity: sha512-+il1gTy0oHwUsBQZyJvukbB4vPMdcYBrFHa0Uc4AizLxbq6BOYC51Rv4tWocX9BLBDLZ4kc6qUFpQ6HRgL+3zw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.17.0
+      '@babel/types': 7.18.2
     dev: true
 
   /@babel/helper-split-export-declaration/7.16.7:
@@ -602,7 +611,7 @@ packages:
       '@babel/helper-function-name': 7.17.9
       '@babel/template': 7.16.7
       '@babel/traverse': 7.17.9
-      '@babel/types': 7.17.0
+      '@babel/types': 7.18.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -624,7 +633,7 @@ packages:
     dependencies:
       '@babel/template': 7.16.7
       '@babel/traverse': 7.18.0
-      '@babel/types': 7.18.0
+      '@babel/types': 7.18.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -650,7 +659,7 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      '@babel/types': 7.18.0
+      '@babel/types': 7.18.2
     dev: true
 
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/7.16.7_@babel+core@7.17.9:
@@ -3132,7 +3141,7 @@ packages:
       '@babel/helper-plugin-utils': 7.16.7
       '@babel/plugin-proposal-unicode-property-regex': 7.16.7_@babel+core@7.17.9
       '@babel/plugin-transform-dotall-regex': 7.16.7_@babel+core@7.17.9
-      '@babel/types': 7.17.0
+      '@babel/types': 7.18.2
       esutils: 2.0.3
     dev: true
 
@@ -3145,7 +3154,7 @@ packages:
       '@babel/helper-plugin-utils': 7.16.7
       '@babel/plugin-proposal-unicode-property-regex': 7.16.7_@babel+core@7.18.0
       '@babel/plugin-transform-dotall-regex': 7.16.7_@babel+core@7.18.0
-      '@babel/types': 7.17.0
+      '@babel/types': 7.18.2
       esutils: 2.0.3
     dev: true
 
@@ -3252,13 +3261,13 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.16.7
-      '@babel/generator': 7.18.0
+      '@babel/generator': 7.18.2
       '@babel/helper-environment-visitor': 7.16.7
       '@babel/helper-function-name': 7.17.9
       '@babel/helper-hoist-variables': 7.16.7
       '@babel/helper-split-export-declaration': 7.16.7
       '@babel/parser': 7.18.0
-      '@babel/types': 7.18.0
+      '@babel/types': 7.18.2
       debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
@@ -3274,6 +3283,14 @@ packages:
 
   /@babel/types/7.18.0:
     resolution: {integrity: sha512-vhAmLPAiC8j9K2GnsnLPCIH5wCrPpYIVBCWRBFDCB7Y/BXLqi/O+1RSTTM2bsmg6U/551+FCf9PNPxjABmxHTw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-validator-identifier': 7.16.7
+      to-fast-properties: 2.0.0
+    dev: true
+
+  /@babel/types/7.18.2:
+    resolution: {integrity: sha512-0On6B8A4/+mFUto5WERt3EEuG1NznDirvwca1O8UwXQHVY8g3R7OzYgxXdOfMwLO08UrpUD/2+3Bclyq+/C94Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-validator-identifier': 7.16.7
@@ -3527,8 +3544,8 @@ packages:
       typescript: '>= 4.3.x'
       vite: '>2.0.0-0'
     dependencies:
-      glob: 7.2.0
-      glob-promise: 4.2.2_glob@7.2.0
+      glob: 7.2.3
+      glob-promise: 4.2.2_glob@7.2.3
       magic-string: 0.26.1
       react-docgen-typescript: 2.2.2_typescript@4.6.4
       typescript: 4.6.4
@@ -3552,11 +3569,6 @@ packages:
       '@jridgewell/trace-mapping': 0.3.13
     dev: true
 
-  /@jridgewell/resolve-uri/3.0.5:
-    resolution: {integrity: sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==}
-    engines: {node: '>=6.0.0'}
-    dev: true
-
   /@jridgewell/resolve-uri/3.0.7:
     resolution: {integrity: sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==}
     engines: {node: '>=6.0.0'}
@@ -3565,10 +3577,6 @@ packages:
   /@jridgewell/set-array/1.1.1:
     resolution: {integrity: sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ==}
     engines: {node: '>=6.0.0'}
-    dev: true
-
-  /@jridgewell/sourcemap-codec/1.4.11:
-    resolution: {integrity: sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==}
     dev: true
 
   /@jridgewell/sourcemap-codec/1.4.13:
@@ -3585,8 +3593,8 @@ packages:
   /@jridgewell/trace-mapping/0.3.7:
     resolution: {integrity: sha512-8XC0l0PwCbdg2Uc8zIIf6djNX3lYiz9GqQlC1LJ9WQvTYvcfP8IA9K2IKRnPm5tAX6X/+orF+WwKZ0doGcgJlg==}
     dependencies:
-      '@jridgewell/resolve-uri': 3.0.5
-      '@jridgewell/sourcemap-codec': 1.4.11
+      '@jridgewell/resolve-uri': 3.0.7
+      '@jridgewell/sourcemap-codec': 1.4.13
     dev: true
 
   /@mdx-js/mdx/1.6.22:
@@ -3619,6 +3627,14 @@ packages:
     resolution: {integrity: sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg==}
     peerDependencies:
       react: ^16.13.1 || ^17.0.0
+    dev: true
+
+  /@mdx-js/react/1.6.22_react@16.14.0:
+    resolution: {integrity: sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg==}
+    peerDependencies:
+      react: ^16.13.1 || ^17.0.0
+    dependencies:
+      react: 16.14.0
     dev: true
 
   /@mdx-js/util/1.6.22:
@@ -3801,7 +3817,7 @@ packages:
       '@storybook/core-events': 6.5.4
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/docs-tools': 6.5.4
-      '@storybook/mdx1-csf': 0.0.1-canary.1.eed86d7.0_@babel+core@7.17.9
+      '@storybook/mdx1-csf': 0.0.2-canary.5.6cee405.0_@babel+core@7.17.9
       '@storybook/node-logger': 6.5.4
       '@storybook/postinstall': 6.5.4
       '@storybook/preview-web': 6.5.4
@@ -4589,7 +4605,7 @@ packages:
       '@storybook/core-common': 6.5.4_eaop5v7njzil2a56s2smd7f5wy
       '@storybook/core-events': 6.5.4
       '@storybook/csf': 0.0.2--canary.4566f4d.1
-      '@storybook/csf-tools': 6.5.4
+      '@storybook/csf-tools': 6.5.4_react@16.14.0
       '@storybook/manager-webpack4': 6.5.4_eaop5v7njzil2a56s2smd7f5wy
       '@storybook/node-logger': 6.5.4
       '@storybook/semver': 7.3.2
@@ -4704,7 +4720,7 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/csf-tools/6.5.4:
+  /@storybook/csf-tools/6.5.4_react@16.14.0:
     resolution: {integrity: sha512-mCAO8Ddig5PzXiI4HxiWhdLmPPpaovzVxqdh7g31k3fhpnRkQrKwftNGTW/ArFDdisMjB1+gm+ZOVACZg0pO4w==}
     peerDependencies:
       '@storybook/mdx2-csf': '*'
@@ -4713,20 +4729,21 @@ packages:
         optional: true
     dependencies:
       '@babel/core': 7.18.0
-      '@babel/generator': 7.18.0
+      '@babel/generator': 7.18.2
       '@babel/parser': 7.18.0
       '@babel/plugin-transform-react-jsx': 7.17.12_@babel+core@7.18.0
       '@babel/preset-env': 7.18.0_@babel+core@7.18.0
       '@babel/traverse': 7.18.0
-      '@babel/types': 7.18.0
+      '@babel/types': 7.18.2
       '@storybook/csf': 0.0.2--canary.4566f4d.1
-      '@storybook/mdx1-csf': 0.0.1-canary.1.eed86d7.0_@babel+core@7.18.0
+      '@storybook/mdx1-csf': 0.0.2-canary.5.6cee405.0_bulxuubf6ggdxnp6z2exkrzdzy
       core-js: 3.22.1
       fs-extra: 9.1.0
       global: 4.4.0
       regenerator-runtime: 0.13.9
       ts-dedent: 2.2.0
     transitivePeerDependencies:
+      - react
       - supports-color
     dev: true
 
@@ -4832,14 +4849,15 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/mdx1-csf/0.0.1-canary.1.eed86d7.0_@babel+core@7.17.9:
-    resolution: {integrity: sha512-KOoTWeseRyJYU5qzEWahgNRhRLgHzPrWx4jIiK4oI9MmNx81cD0B0o24Gq04Iyt89X4jTk+VPHc5REJO1Gs99Q==}
+  /@storybook/mdx1-csf/0.0.2-canary.5.6cee405.0_@babel+core@7.17.9:
+    resolution: {integrity: sha512-LRQ086H27/Ro8jQPoXb3hb0LgYokurqqFf4eDNSv/EqvzUihGrurvpiIGfTJ6JDzWZbiX1NIsqe8dx4jKpEGMw==}
     dependencies:
-      '@babel/generator': 7.18.0
+      '@babel/generator': 7.18.2
       '@babel/parser': 7.18.0
       '@babel/preset-env': 7.18.0_@babel+core@7.17.9
-      '@babel/types': 7.18.0
+      '@babel/types': 7.18.2
       '@mdx-js/mdx': 1.6.22
+      '@mdx-js/react': 1.6.22
       '@types/lodash': 4.14.182
       js-string-escape: 1.0.1
       loader-utils: 2.0.2
@@ -4848,17 +4866,19 @@ packages:
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@babel/core'
+      - react
       - supports-color
     dev: true
 
-  /@storybook/mdx1-csf/0.0.1-canary.1.eed86d7.0_@babel+core@7.18.0:
-    resolution: {integrity: sha512-KOoTWeseRyJYU5qzEWahgNRhRLgHzPrWx4jIiK4oI9MmNx81cD0B0o24Gq04Iyt89X4jTk+VPHc5REJO1Gs99Q==}
+  /@storybook/mdx1-csf/0.0.2-canary.5.6cee405.0_bulxuubf6ggdxnp6z2exkrzdzy:
+    resolution: {integrity: sha512-LRQ086H27/Ro8jQPoXb3hb0LgYokurqqFf4eDNSv/EqvzUihGrurvpiIGfTJ6JDzWZbiX1NIsqe8dx4jKpEGMw==}
     dependencies:
-      '@babel/generator': 7.18.0
+      '@babel/generator': 7.18.2
       '@babel/parser': 7.18.0
       '@babel/preset-env': 7.18.0_@babel+core@7.18.0
-      '@babel/types': 7.18.0
+      '@babel/types': 7.18.2
       '@mdx-js/mdx': 1.6.22
+      '@mdx-js/react': 1.6.22_react@16.14.0
       '@types/lodash': 4.14.182
       js-string-escape: 1.0.1
       loader-utils: 2.0.2
@@ -4867,6 +4887,7 @@ packages:
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@babel/core'
+      - react
       - supports-color
     dev: true
 
@@ -5738,8 +5759,8 @@ packages:
   /@vue/shared/3.2.33:
     resolution: {integrity: sha512-UBc1Pg1T3yZ97vsA2ueER0F6GbJebLHYlEi4ou1H5YL4KWvMOOWwpYo9/QpWq93wxKG6Wo13IY74Hcn/f7c7Bg==}
 
-  /@vue/test-utils/2.0.0-rc.20_vue@3.2.33:
-    resolution: {integrity: sha512-aSkOAzM/ZlIyYgN7yj661FTjhFZZy5i9+FUbbDNoMGYA4F1WKwDdcDCPj9B/qzt3wGFkuCP5PO6SBtdSTMEhIA==}
+  /@vue/test-utils/2.0.0_vue@3.2.33:
+    resolution: {integrity: sha512-zL5kygNq7hONrO1CzaUGprEAklAX+pH8J1MPMCU3Rd2xtSYkZ+PmKU3oEDRg8VAGdL5lNJHzDgrud5amFPtirw==}
     peerDependencies:
       vue: ^3.0.1
     dependencies:
@@ -6515,7 +6536,7 @@ packages:
     resolution: {integrity: sha512-GAwkz0AihzY5bkwIY5QDR+LvsRQgB/B+1foMPvi0FZPMl5fjD7ICiznUiBdLYMH1QYe6vqu4gWYytZOccLouFw==}
     engines: {node: '>= 10.0.0'}
     dependencies:
-      '@babel/types': 7.18.0
+      '@babel/types': 7.18.2
     dev: true
 
   /bail/1.0.5:
@@ -6790,8 +6811,8 @@ packages:
     engines: {node: '>= 0.8'}
     dev: true
 
-  /c8/7.11.0:
-    resolution: {integrity: sha512-XqPyj1uvlHMr+Y1IeRndC2X5P7iJzJlEJwBpCdBbq2JocXOgJfr+JVfJkyNMGROke5LfKrhSFXGFXnwnRJAUJw==}
+  /c8/7.11.3:
+    resolution: {integrity: sha512-6YBmsaNmqRm9OS3ZbIiL2EZgi1+Xc4O24jL3vMYGE6idixYuGdy76rIfIdltSKDj9DpLNrcXSonUTR1miBD0wA==}
     engines: {node: '>=10.12.0'}
     hasBin: true
     dependencies:
@@ -6804,7 +6825,7 @@ packages:
       istanbul-reports: 3.1.4
       rimraf: 3.0.2
       test-exclude: 6.0.0
-      v8-to-istanbul: 8.1.1
+      v8-to-istanbul: 9.0.0
       yargs: 16.2.0
       yargs-parser: 20.2.9
     dev: true
@@ -6815,7 +6836,7 @@ packages:
       bluebird: 3.7.2
       chownr: 1.1.4
       figgy-pudding: 3.5.2
-      glob: 7.2.0
+      glob: 7.2.3
       graceful-fs: 4.2.10
       infer-owner: 1.0.4
       lru-cache: 5.1.1
@@ -7243,7 +7264,7 @@ packages:
     resolution: {integrity: sha512-vCrqcSIq4//Gx74TXXCGnHpulY1dskqLTFGDmhrGxzeXL8lF8kvXv6mpNWlJj1uD4DW23D4ljAqbY4RRaaUZIw==}
     dependencies:
       '@babel/parser': 7.18.0
-      '@babel/types': 7.18.0
+      '@babel/types': 7.18.2
     dev: true
 
   /constants-browserify/1.0.0:
@@ -8540,7 +8561,7 @@ packages:
     dependencies:
       '@babel/traverse': 7.17.9
       '@babel/types': 7.17.0
-      c8: 7.11.0
+      c8: 7.11.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -9223,6 +9244,16 @@ packages:
     dependencies:
       '@types/glob': 7.2.0
       glob: 7.2.0
+    dev: true
+
+  /glob-promise/4.2.2_glob@7.2.3:
+    resolution: {integrity: sha512-xcUzJ8NWN5bktoTIX7eOclO1Npxd/dyVqUJxlLIDasT4C7KZyqlPIwkdJ0Ypiy3p2ZKahTjK4M9uC3sNSfNMzw==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      glob: ^7.1.6
+    dependencies:
+      '@types/glob': 7.2.0
+      glob: 7.2.3
     dev: true
 
   /glob-to-regexp/0.3.0:
@@ -12588,21 +12619,21 @@ packages:
     resolution: {integrity: sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==}
     hasBin: true
     dependencies:
-      glob: 7.2.0
+      glob: 7.2.3
     dev: true
 
   /rimraf/2.7.1:
     resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
     hasBin: true
     dependencies:
-      glob: 7.2.0
+      glob: 7.2.3
     dev: true
 
   /rimraf/3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     hasBin: true
     dependencies:
-      glob: 7.2.0
+      glob: 7.2.3
     dev: true
 
   /ripemd160/2.0.2:
@@ -13404,7 +13435,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       '@istanbuljs/schema': 0.1.3
-      glob: 7.2.0
+      glob: 7.2.3
       minimatch: 3.1.2
     dev: true
 
@@ -13982,13 +14013,13 @@ packages:
     resolution: {integrity: sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==}
     dev: true
 
-  /v8-to-istanbul/8.1.1:
-    resolution: {integrity: sha512-FGtKtv3xIpR6BYhvgH8MI/y78oT7d8Au3ww4QIxymrCtZEh5b8gCw2siywE+puhEmuWKDtmfrvF5UlB298ut3w==}
+  /v8-to-istanbul/9.0.0:
+    resolution: {integrity: sha512-HcvgY/xaRm7isYmyx+lFKA4uQmfUbN0J4M0nNItvzTvH/iQ9kW5j/t4YSR+Ge323/lrgDAWJoF46tzGQHwBHFw==}
     engines: {node: '>=10.12.0'}
     dependencies:
+      '@jridgewell/trace-mapping': 0.3.13
       '@types/istanbul-lib-coverage': 2.0.4
       convert-source-map: 1.8.0
-      source-map: 0.7.3
     dev: true
 
   /validate-npm-package-license/3.0.4:
@@ -14499,7 +14530,7 @@ packages:
     engines: {node: '>= 10.0.0'}
     dependencies:
       '@babel/parser': 7.18.0
-      '@babel/types': 7.18.0
+      '@babel/types': 7.18.2
       assert-never: 1.2.1
       babel-walk: 3.0.0-canary-5
     dev: true

--- a/src/components/ZTag/__tests__/__snapshots__/ztag.test.ts.snap
+++ b/src/components/ZTag/__tests__/__snapshots__/ztag.test.ts.snap
@@ -1,0 +1,8 @@
+// Vitest Snapshot v1
+
+exports[`mount component 1`] = `
+"<div class=\\"z-tag gap-x-2 inline-flex items-center rounded-full justify-evenly px-4 py-1 text-sm border-2 border-solid border-transparent bg-slate-800 text-slate-50\\">
+  <!--v-if-->
+  <!--v-if-->
+</div>"
+`;

--- a/src/components/ZTag/__tests__/ztag.test.ts
+++ b/src/components/ZTag/__tests__/ztag.test.ts
@@ -1,0 +1,11 @@
+import { mount } from '@vue/test-utils'
+import ZTag from '../ZTag.vue'
+import { test, expect } from 'vitest'
+
+test('mount component', () => {
+  expect(ZTag).toBeTruthy()
+
+  const wrapper = mount(ZTag, { icon: { icon: 'activity' } })
+
+  expect(wrapper.html()).toMatchSnapshot()
+})

--- a/src/utils/__tests__/unplugin-config.spec.ts
+++ b/src/utils/__tests__/unplugin-config.spec.ts
@@ -1,0 +1,12 @@
+import { expect } from 'chai'
+import { test } from 'vitest'
+import { unPluginConfig } from '../unplugin-config'
+
+test('unplugin config', () => {
+  //? Ensure the compiler is always set to `vue3`
+  expect(unPluginConfig.compiler).eq('vue3')
+  //? Ensure the scale is always set to `1`
+  expect(unPluginConfig.scale).eq(1)
+  //? Ensure that default classes always contain `z-icon`
+  expect(unPluginConfig.defaultClass).contains('z-icon')
+})

--- a/src/utils/__tests__/vue-helper.spec.ts
+++ b/src/utils/__tests__/vue-helper.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'vitest'
+import { cloneVNodes } from '../vue-helper'
+import { Fragment, h } from 'vue'
+
+const VNodesMock = [
+  h('p', 'start'),
+  h(
+    Fragment,
+    Array.from({ length: 20 }).map(() => {
+      return h('p', 'hi')
+    })
+  ),
+  h('p', 'end')
+]
+
+describe('cloneVNodes', () => {
+  test('it clones a set of VNodes with Fragments expanded when `flattenFragments = true`', () => {
+    const clonedVNodes = cloneVNodes(VNodesMock, { test: 'a' }, true)
+    expect(clonedVNodes.length).eq(22)
+  })
+
+  test('it clones a set of VNodes with Fragments without expanding Fragments when `flattenFragments = false`', () => {
+    const clonedVNodes = cloneVNodes(VNodesMock, { test: 'a' })
+    expect(clonedVNodes.length).eq(3)
+  })
+})

--- a/src/utils/unplugin-config.ts
+++ b/src/utils/unplugin-config.ts
@@ -1,4 +1,6 @@
-const unPluginConfig = {
+import type { Options } from 'unplugin-icons/dist/types'
+
+const unPluginConfig: Options = {
   scale: 1,
   defaultClass: 'z-icon',
   compiler: 'vue3'

--- a/src/utils/vue-helper.ts
+++ b/src/utils/vue-helper.ts
@@ -15,7 +15,12 @@ const cloneVNodes = (
 ): VNode[] => {
   return nodes.reduce((flatArray, child) => {
     if (flattenFragments && child.type === Fragment) {
-      return cloneVNodes(child.children as VNode[], { ...customProps, ...child.props })
+      return flatArray.concat(
+        cloneVNodes(child.children as VNode[], {
+          ...customProps,
+          ...child.props
+        })
+      )
     }
 
     return flatArray.concat(cloneVNode(child, { ...customProps, ...child.props }))

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,6 +34,15 @@ export default defineConfig({
     environment: 'jsdom',
     coverage: {
       reporter: ['text', 'html', 'cobertura'],
+      exclude: [
+        '*.config.{js,ts}',
+        '.storybook/*',
+        '**/*.stories.{js,ts}',
+        'src/main.ts',
+        '**/*.d.ts',
+        '.eslintrc.cjs',
+        '**/__tests__/*'
+      ],
       all: true
     }
   }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,5 +28,13 @@ export default defineConfig({
         }
       }
     }
+  },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    coverage: {
+      reporter: ['text', 'html', 'cobertura'],
+      all: true
+    }
   }
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from 'vitest/config'
-
-export default defineConfig({
-  test: {
-    coverage: { reporter: ['text', 'html', 'cobertura'] }
-  }
-})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    coverage: { reporter: ['text', 'html', 'cobertura'] }
+  }
+})


### PR DESCRIPTION
## Description

- Fix an error in `cloneVNodes` to ensure that the return array always contains elements.
- Add tests and test coverage analyzer.

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes in this PR

- Return the expanded array when de-structuring a fragment.
- Update `vitest` and `@vue/test-utils`.
- Setup tests and test coverage analyzer.

## Note to reviewers

- https://github.com/vitest-dev/vitest/issues/680 needs tracking for ensuring files are covered properly in coverage.
